### PR TITLE
Update BorderlessWindow.cpp

### DIFF
--- a/BorderlessWindow/src/BorderlessWindow.cpp
+++ b/BorderlessWindow/src/BorderlessWindow.cpp
@@ -23,6 +23,7 @@ namespace {
 
     auto maximized(HWND hwnd) -> bool {
         WINDOWPLACEMENT placement;
+        placement.length = sizeof(WINDOWPLACEMENT);
         if (!::GetWindowPlacement(hwnd, &placement)) {
               return false;
         }


### PR DESCRIPTION
// add: placement.length = sizeof(WINDOWPLACEMENT);
// remove uninitialized warns in IDEs
// https://learn.microsoft.com/en-us/windows/win32/api/winuser/ns-winuser-windowplacement